### PR TITLE
added support for authorization policies

### DIFF
--- a/sample/Demo/Controllers/OtherController.cs
+++ b/sample/Demo/Controllers/OtherController.cs
@@ -19,5 +19,9 @@ namespace Demo.Controllers
         {
             return id;
         }
+
+        public void Unreachable() { }
+
+        public void Unreachable2() { }
     }
 }

--- a/sample/Demo/Demo.csproj
+++ b/sample/Demo/Demo.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.1" />

--- a/sample/Demo/Startup.cs
+++ b/sample/Demo/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Strathweb.TypedRouting.AspNetCore;
 using Demo.Controllers;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Demo
 {
@@ -21,10 +22,20 @@ namespace Demo
             services.AddSingleton<TimerFilter>();
             services.AddSingleton<AnnotationFilter>();
 
+            services.AddAuthorization(o =>
+            {
+                o.AddPolicy("MyPolicy", b => b.RequireAuthenticatedUser());
+            });
+
             services.AddMvc(opt =>
             {
-                opt.Get("api/items", c => c.Action<ItemsController>(x => x.Get())).WithFilters(new AnnotationFilter());
-                opt.Get("api/items/{id}", c => c.Action<ItemsController>(x => x.Get(Param<int>.Any))).WithName("GetItemById").WithFilter<AnnotationFilter>();
+                opt.Get("api/items", c => c.Action<ItemsController>(x => x.Get())).
+                    WithFilters(new AnnotationFilter());
+
+                opt.Get("api/items/{id}", c => c.Action<ItemsController>(x => x.Get(Param<int>.Any))).
+                    WithName("GetItemById").
+                    WithFilter<AnnotationFilter>();
+
                 opt.Post("api/items", c => c.Action<ItemsController>(x => x.Post(Param<Item>.Any)));
                 opt.Put("api/items/{id}", c => c.Action<ItemsController>(x => x.Put(Param<int>.Any, Param<Item>.Any)));
                 opt.Delete("api/items/{id}", c => c.Action<ItemsController>(x => x.Delete(Param<int>.Any)));
@@ -33,12 +44,19 @@ namespace Demo
                     WithConstraints(new MandatoryHeaderConstraint("CustomHeader"));
 
                 opt.Get("api/other/{id:int}", c => c.Action<OtherController>(x => x.Action2(Param<int>.Any)));
+
+                opt.Get("api/secure_string", c => c.Action<OtherController>(x => x.Unreachable()).
+                    WithAuthorizationPolicy("MyPolicy"));
+
+                opt.Get("api/secure_instance", c => c.Action<OtherController>(x => x.Unreachable2()).
+                    WithAuthorizationPolicy(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build()));
             }).EnableTypedRouting();
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddDebug();
+            app.UseJwtBearerAuthentication();
             app.UseMvc();
         }
     }

--- a/src/Strathweb.TypedRouting.AspNetCore/TypedRoute.cs
+++ b/src/Strathweb.TypedRouting.AspNetCore/TypedRoute.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Authorization;
 
 namespace Strathweb.TypedRouting.AspNetCore
 {
@@ -91,6 +93,19 @@ namespace Strathweb.TypedRouting.AspNetCore
         public TypedRoute WithFilter<T>() where T : IFilterMetadata
         {
             FilterTypes.Add(typeof(T));
+            return this;
+        }
+
+        public TypedRoute WithAuthorizationPolicy(string authorizationPolicyName)
+        {
+            Filters.Add(new AuthorizeFilter(authorizationPolicyName));
+            return this;
+        }
+
+        public TypedRoute WithAuthorizationPolicy(AuthorizationPolicy policy)
+        {
+            Filters.Add(new AuthorizeFilter(policy));
+
             return this;
         }
     }

--- a/tests/Strathweb.TypedRouting.AspNetCore.Tests/IntegrationTests.cs
+++ b/tests/Strathweb.TypedRouting.AspNetCore.Tests/IntegrationTests.cs
@@ -76,6 +76,28 @@ namespace Strathweb.TypedRouting.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task AuthorizationPolicy_DefineViaString()
+        {
+            var client = _server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "api/secure_string");
+            var result = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task AuthorizationPolicy_DefineViaPolicyInstance()
+        {
+            var client = _server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "api/secure_instance");
+            var result = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+        }
+
+        [Fact]
         public async Task Post()
         {
             var client = _server.CreateClient();


### PR DESCRIPTION
This builds upon the filter support by adding a special entry for authorization policies - both as strings and as policy instances.