### PR TITLE
fixed a bug with removed selectors

### DIFF
--- a/sample/Demo/Controllers/OtherController.cs
+++ b/sample/Demo/Controllers/OtherController.cs
@@ -21,7 +21,5 @@ namespace Demo.Controllers
         }
 
         public void Unreachable() { }
-
-        public void Unreachable2() { }
     }
 }

--- a/sample/Demo/Startup.cs
+++ b/sample/Demo/Startup.cs
@@ -48,7 +48,7 @@ namespace Demo
                 opt.Get("api/secure_string", c => c.Action<OtherController>(x => x.Unreachable()).
                     WithAuthorizationPolicy("MyPolicy"));
 
-                opt.Get("api/secure_instance", c => c.Action<OtherController>(x => x.Unreachable2()).
+                opt.Get("api/secure_instance", c => c.Action<OtherController>(x => x.Unreachable()).
                     WithAuthorizationPolicy(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build()));
             }).EnableTypedRouting();
         }

--- a/src/Strathweb.TypedRouting.AspNetCore/TypedRoutingApplicationModelConvention.cs
+++ b/src/Strathweb.TypedRouting.AspNetCore/TypedRoutingApplicationModelConvention.cs
@@ -31,6 +31,7 @@ namespace Strathweb.TypedRouting.AspNetCore
                     foreach (var route in typedRoutes)
                     {
                         var action = controller.Actions.FirstOrDefault(x => x.ActionMethod == route.ActionMember);
+                        if (action == null) continue;
 
                         var selectorModel = new SelectorModel
                         {
@@ -60,8 +61,13 @@ namespace Strathweb.TypedRouting.AspNetCore
                             }
                         }
 
-                        action?.Selectors.Clear();
-                        action?.Selectors.Insert(0, selectorModel);
+                        var nonAttributeSelectors = action.Selectors.Where(x => x.AttributeRouteModel == null).ToArray();
+                        foreach (var nonAttributeSelector in nonAttributeSelectors)
+                        {
+                            action.Selectors.Remove(nonAttributeSelector);
+                        }
+
+                        action.Selectors.Insert(0, selectorModel);
                     }
                 }
             }


### PR DESCRIPTION
When same method was processed for routes multiple times, each new route would remove previous selectors. This is now fixed.

Fixes #18 